### PR TITLE
changed api key to also pull from opts

### DIFF
--- a/lib/client/tesla.ex
+++ b/lib/client/tesla.ex
@@ -11,11 +11,12 @@ defmodule ExSignal.Client.Tesla do
   @impl true
   def build_client(opts \\ []) do
     timeout = Keyword.get(opts, :timeout, 30_000)
+    api_key = Keyword.get(opts, :api_key, ExSignal.config(:api_key))
 
     middleware = [
       {Tesla.Middleware.BaseUrl, ExSignal.config(:api_url, "https://onesignal.com/api/v1")},
       Tesla.Middleware.JSON,
-      {Tesla.Middleware.Headers, [{"Authorization", "Basic #{ExSignal.config(:api_key)}"}]},
+      {Tesla.Middleware.Headers, [{"Authorization", "Basic #{api_key}"}]},
     ]
     adapter = {Tesla.Adapter.Hackney, [recv_timeout: timeout]}
 


### PR DESCRIPTION
needed to make it so that ex_signal would support the ability to have multiple apps get pushed from the same app. since different apps have different api keys, I needed to make it an option. should fallback to previous behavior if one is not provided.